### PR TITLE
Log snippet file name and line on parse error

### DIFF
--- a/src/CodeSnippetsService.ts
+++ b/src/CodeSnippetsService.ts
@@ -33,6 +33,7 @@ export class CodeSnippetsService {
   }
 
   getMap(): IVSCodeSnippetMap {
+    let currentFilename = this.textDocument.uri.path.split('/').pop();
     let currentProperty: string | null = null;
     let currentParent: any = [];
     const initCurrentParent = currentParent;
@@ -75,7 +76,8 @@ export class CodeSnippetsService {
         currentParent = previousParents.pop();
       },
       onLiteralValue: onValue,
-      onError: (e: ParseErrorCode, offset: number, length: number) => {
+      onError: (e: ParseErrorCode, offset: number, length: number, startLine: number) => {
+
         if (
           currentParent === initCurrentParent &&
           e === ParseErrorCode.ValueExpected
@@ -83,7 +85,8 @@ export class CodeSnippetsService {
           throw Error(`Parse error: empty content`);
         }
 
-        throw Error(`Parse error`);
+        throw Error(`Parse error: ${ParseErrorCode[e]} in ${currentFilename} (Line: ${startLine}).
+        Tip: Check for trailing commas in the snippet file.`);
       },
     };
     visit(this.textDocument.getText(), visitor);

--- a/src/CodeSnippetsService.ts
+++ b/src/CodeSnippetsService.ts
@@ -76,8 +76,13 @@ export class CodeSnippetsService {
         currentParent = previousParents.pop();
       },
       onLiteralValue: onValue,
-      onError: (e: ParseErrorCode, offset: number, length: number, startLine: number) => {
-
+      onError: (
+        e: ParseErrorCode,
+        offset: number,
+        length: number,
+        startLine: number,
+        startCharacter: number
+      ) => {
         if (
           currentParent === initCurrentParent &&
           e === ParseErrorCode.ValueExpected
@@ -85,9 +90,23 @@ export class CodeSnippetsService {
           throw Error(`Parse error: empty content`);
         }
 
+        let errorType = "Unknown";
+
+        try {
+          // @ts-ignore
+          if (ParseErrorCode[e]) {
+            // @ts-ignore
+            errorType = ParseErrorCode[e];
+          }
+        } catch (error) {
+          console.error(error);
+        }
+
         throw Error(
-          `Parse error: ${ParseErrorCode[e]} in ${currentFilename} (Line: ${startLine}).\n` +
-          `Tip: Check for trailing commas in the snippet file.`
+          `Parse error: ${errorType} in ${currentFilename} (Line: ${
+            startLine + 1
+          }, Char: ${startCharacter + 1}).\n` +
+            `Tip: Check if the file conforms to the JSONC specification, example trailing commas or quotes.`
         );
       },
     };

--- a/src/CodeSnippetsService.ts
+++ b/src/CodeSnippetsService.ts
@@ -85,8 +85,10 @@ export class CodeSnippetsService {
           throw Error(`Parse error: empty content`);
         }
 
-        throw Error(`Parse error: ${ParseErrorCode[e]} in ${currentFilename} (Line: ${startLine}).
-        Tip: Check for trailing commas in the snippet file.`);
+        throw Error(
+          `Parse error: ${ParseErrorCode[e]} in ${currentFilename} (Line: ${startLine}).\n` +
+          `Tip: Check for trailing commas in the snippet file.`
+        );
       },
     };
     visit(this.textDocument.getText(), visitor);


### PR DESCRIPTION
Addresses #13 by outputting the snippet file name and offending line number when a snippet fails to parse.

**Before this change**:

![image](https://user-images.githubusercontent.com/8723433/233726028-d37d771d-daa6-42ab-9c15-25916a9361a4.png)

**After this change**:

![image](https://user-images.githubusercontent.com/8723433/233726420-a8109924-afca-41fe-b214-d8172a68278c.png)

Despite the error message/code being different in the above logs, the root cause was a trailing comma in all cases. I wasn't able to find a way to interpret that, so I simply added a catchall tip for the user to check for trailing commas.