### PR TITLE
Use language-aware icons for snippet files

### DIFF
--- a/src/views/BasicSnippetsExplorerView.ts
+++ b/src/views/BasicSnippetsExplorerView.ts
@@ -3,6 +3,56 @@ import moveSnippets, { movingSnippetsMimeType } from "../core/moveSnippets";
 import getSnippets from "../utils/getSnippets";
 import { ISnippet, ISnippetContainer } from "..";
 
+// Map filename → extension
+const extensionMap = {
+  // Core web
+  html: "html",
+  css: "css",
+  sass: "scss",
+  scss: "scss",
+  less: "less",
+  javascript: "js",
+  javascriptreact: "jsx",
+  jquery: "js",
+  typescript: "ts",
+  typescriptreact: "tsx",
+  // Templates
+  twig: "twig",
+  jinja: "jinja",
+  // Backend / scripting
+  php: "php",
+  python: "py",
+  java: "java",
+  // Data / query
+  json: "json",
+  sql: "sql",
+  // Shell / automation
+  bash: "sh",
+  batch: "bat",
+  bat: "bat",
+  powershell: "ps1",
+  // Platforms / tooling
+  node: "js",
+  npm: "json",
+  // Systems / languages
+  go: "go",
+  rust: "rs",
+  c: "c",
+  cpp: "cpp",
+  csharp: "cs",
+  kotlin: "kt",
+  lua: "lua",
+  dart: "dart",
+  perl: "pl",
+  ruby: "rb",
+  swift: "swift",
+  r: "r",
+  vue: "vue",
+  // Docs
+  markdown: "md",
+  md: "md"
+};
+
 export class SnippetTreeItem extends vscode.TreeItem {
   name?: string = "";
   isFile?: boolean;
@@ -11,8 +61,7 @@ export class SnippetTreeItem extends vscode.TreeItem {
 }
 
 export default abstract class BasicSnippetsExplorerView
-  implements vscode.TreeDataProvider<SnippetTreeItem>
-{
+  implements vscode.TreeDataProvider<SnippetTreeItem> {
   public static viewId = "";
 
   protected abstract _onDidChangeTreeData: vscode.EventEmitter<any>;
@@ -105,8 +154,20 @@ export default abstract class BasicSnippetsExplorerView
 
     const item = new SnippetTreeItem(
       element.name || "",
-      element.children ? vscode.TreeItemCollapsibleState.Collapsed : undefined,
+      element.isFile
+        ? vscode.TreeItemCollapsibleState.Collapsed
+        : element.children
+          ? vscode.TreeItemCollapsibleState.Collapsed
+          : vscode.TreeItemCollapsibleState.None
     );
+    if (element.isFile) {
+      item.iconPath = vscode.ThemeIcon.File;
+      // Map filename → extension
+      const lang = (element.name ?? "").toLowerCase().replace(/\.(json|code-snippets)$/i, "");
+      // Language-specific file icon
+      const langKey = lang as keyof typeof extensionMap;
+      item.resourceUri = vscode.Uri.file(`_.${extensionMap[langKey] ?? "txt"}`);
+    }
     item.command = !element.children ? viewSnippetCommand : undefined;
     item.contextValue = contextValue;
 


### PR DESCRIPTION
This PR improves snippet items display in the Tree View by:

- Assigning language-aware icons using resourceUri
- Making easier to visually distinguish the different sets of snippets
- Aligning icon rendering with the active VS Code icon theme

The implementation infers file type from filename, as long as the filename matches a supported language, ex.: "javascript", "typescript", "python"... and the extension is "json" or "code-snippets". If no match is found, a basic file icon is shown. The implementation does not affect existing behavior outside icon rendering.

This is my first contribution. I apologize in advance for anything I may have done wrong.

Before and after images:

<img width="900" height="1256" alt="before" src="https://github.com/user-attachments/assets/53e2de74-6940-4866-b459-1b2aa3a93345" />

<img width="892" height="1271" alt="after" src="https://github.com/user-attachments/assets/383a3416-4d04-40af-bcb7-7a0eb8973b4c" />
